### PR TITLE
Improve additional column handling and add tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,109 @@
-# test-keiba
-テスト競馬
+# 競馬出走表ジェネレーター
+
+このリポジトリは、TOML で記述したレース情報から競馬の出走表（評価表）を HTML として出力するための簡単なツールです。スクリーンショットで示されたような評価表を、共通のテンプレートに従って素早く作成できます。
+
+## 必要要件
+
+- Python 3.11 以上（標準ライブラリのみを使用しています）
+
+## 使い方
+
+1. レース情報を TOML 形式で用意します。テンプレートとして `data/sample_race.toml` を参照してください。
+2. 次のコマンドで HTML ファイルを生成します。
+
+   ```bash
+   python generate_race_table.py data/sample_race.toml output/sample_race.html
+   ```
+
+   `output` 引数を省略した場合は、入力ファイルと同じ場所に `.html` を付けたファイルが出力されます。
+
+3. 生成された HTML ファイルをブラウザで開くと、評価付きの出走表を確認できます。
+
+## TOML ファイルの構成
+
+```toml
+[race]
+title = "今回の査定評価に関わる項目"   # 表のタイトル
+subtitle = "天皇賞（春） 芝3200m (右外 C)" # 任意: サブタイトル
+additional_columns = ["前走", "ローテ"]     # 任意: 評価以外に表示するカスタム列
+footnote = "注記をここに記述"                # 任意: 表下部に表示するフッター
+
+distance_note = "※芝2000m以上/1600〜1800m"  # 任意: タイトル下の補足
+
+[[criteria]]
+key = "枠順"
+label = "枠順"
+description = "内枠がプラス評価。"
+
+[[criteria]]
+key = "距離適性"
+label = "距離適性"
+
+# ... 任意の数だけ criteria を追加できます
+
+[legend]
+枠順 = "評価基準を説明するテキスト"
+距離適性 = "評価基準を説明するテキスト"
+
+[[horses]]
+post_position = 1
+number = 1
+name = "アスクワイルドモア"
+sex_age = "牡4"
+weight = "58"
+jockey = "岩田望来"
+running_style = "差し"
+ratings = { 枠順 = "A", 距離適性 = "B" }
+notes = { 前走 = "日経賞 6着", ローテ = "中3週" }
+comments = "内枠を活かせれば上位争いも。"
+
+# ... 出走馬の数だけ追加
+```
+
+### 各セクションの説明
+
+- `[race]`
+  - `title`, `subtitle`, `distance_note` はヘッダーに表示されます。
+  - `additional_columns` は各馬固有のメモ情報（`notes` のキー）を列として表示します。文字列を指定するとキーと表示ラベルが同じになり、`{ key = "identifier", label = "表示名" }` のようにテーブルで書くと表示名だけを変えられます。
+  - `footnote` は表の下部に小さく表示する備考欄です。
+- `[[criteria]]`
+  - 評価軸を定義します。`key` はデータ上の識別子、`label` は表に表示するラベルです。
+  - `description` を設定すると、表下部の「評価基準」欄に説明として表示されます（`legend` に同じキーの説明がある場合は `legend` が優先されます）。
+- `[legend]`
+  - 各評価軸に対する補足説明を自由に記述できます。省略した場合は `criteria` の `description` がそのまま表示されます。
+- `[[horses]]`
+  - 1 頭につき 1 テーブル。`ratings` には `key` に対応する評価値（S/A/B/C…など）を指定します。
+  - `notes` は `additional_columns` で定義した列に対応する文字列を指定します。
+  - `running_style` や `comments` は任意です。値が設定されている場合のみ列が表示されます。
+
+## ブラケット色について
+
+枠番（1〜8）に応じて JRA の公式色に近い配色でセル背景色を自動設定しています。
+
+| 枠番 | 色 | 文字色 |
+| ---- | --- | ------ |
+| 1 | 白 (#ffffff) | 黒 |
+| 2 | 黒 (#000000) | 白 |
+| 3 | 赤 (#ff4b4b) | 白 |
+| 4 | 青 (#1a7cff) | 白 |
+| 5 | 黄 (#ffd447) | 黒 |
+| 6 | 緑 (#3ab66b) | 白 |
+| 7 | 橙 (#ff7f27) | 黒 |
+| 8 | 桃 (#ff7fd1) | 黒 |
+
+## サンプルデータ
+
+- `data/sample_race.toml`: サンプルの入力ファイル
+- `output/sample_race.html`: 上記の TOML から生成したサンプル（`python generate_race_table.py data/sample_race.toml output/sample_race.html` で生成できます）
+
+## テスト
+
+変更を加えた際は次のコマンドでユニットテストを実行して動作を確認できます。
+
+```bash
+python -m unittest
+```
+
+## ライセンス
+
+このリポジトリ内のコードは MIT ライセンスで提供されています。

--- a/data/sample_race.toml
+++ b/data/sample_race.toml
@@ -1,0 +1,116 @@
+[race]
+title = "今回の査定評価に関わる項目"
+subtitle = "天皇賞（春） 芝3200m (右外 C)"
+distance_note = "※芝2000m以上/1600〜1800m"
+additional_columns = ["前走", "ローテ", "適性", "天候", "ミドルペース", "上がり順位"]
+footnote = "この表はサンプルデータを用いたデモンストレーションです。"
+
+[[criteria]]
+key = "枠順"
+label = "枠順"
+description = "内枠がプラス評価。"
+
+[[criteria]]
+key = "距離適性"
+label = "距離適性"
+description = "3000m以上での実績。"
+
+[[criteria]]
+key = "展開"
+label = "展開"
+description = "想定されるペースと脚質の噛み合い。"
+
+[[criteria]]
+key = "状態"
+label = "調教"
+description = "直前追い切りの時計や動き。"
+
+[[criteria]]
+key = "実績"
+label = "重賞実績"
+description = "G1・G2での好走歴。"
+
+[[criteria]]
+key = "舞台"
+label = "舞台適性"
+description = "京都芝3200mとの相性。"
+
+[[criteria]]
+key = "瞬発力"
+label = "瞬発力"
+description = "ラスト3Fの伸び。"
+
+[[criteria]]
+key = "スタミナ"
+label = "スタミナ"
+description = "長距離への耐久力。"
+
+[legend]
+"枠順" = "S〜Eの5段階で内枠高評価。"
+"距離適性" = "長距離経験の豊富さ。"
+"展開" = "想定ペースとの相性。"
+"状態" = "中間の調教内容。"
+"実績" = "重賞の実績。"
+"舞台" = "コースとの相性。"
+"瞬発力" = "上がり性能。"
+"スタミナ" = "持久力。"
+
+[[horses]]
+post_position = 1
+number = 1
+name = "アスクワイルドモア"
+sex_age = "牡4"
+weight = "58"
+jockey = "岩田望来"
+running_style = "差し"
+ratings = { "枠順" = "A", "距離適性" = "B", "展開" = "B", "状態" = "A", "実績" = "B", "舞台" = "B", "瞬発力" = "B", "スタミナ" = "A" }
+notes = { "前走" = "日経賞 6着", "ローテ" = "中3週", "適性" = "芝長距離", "天候" = "雨◎", "ミドルペース" = "○", "上がり順位" = "4位" }
+comments = "内枠を活かせれば上位争いも。"
+
+[[horses]]
+post_position = 2
+number = 3
+name = "ジャスティンパレス"
+sex_age = "牡4"
+weight = "58"
+jockey = "C.ルメール"
+running_style = "先行"
+ratings = { "枠順" = "S", "距離適性" = "A", "展開" = "A", "状態" = "S", "実績" = "A", "舞台" = "A", "瞬発力" = "A", "スタミナ" = "A" }
+notes = { "前走" = "阪神大賞典 1着", "ローテ" = "中5週", "適性" = "芝長距離", "天候" = "晴◎", "ミドルペース" = "◎", "上がり順位" = "1位" }
+comments = "長距離G2を快勝。状態も抜群。"
+
+[[horses]]
+post_position = 3
+number = 5
+name = "ブレークアップ"
+sex_age = "牡5"
+weight = "58"
+jockey = "松山弘平"
+running_style = "先行"
+ratings = { "枠順" = "B", "距離適性" = "B", "展開" = "B", "状態" = "B", "実績" = "B", "舞台" = "B", "瞬発力" = "C", "スタミナ" = "B" }
+notes = { "前走" = "阪神大賞典 4着", "ローテ" = "中5週", "適性" = "芝長距離", "天候" = "晴○", "ミドルペース" = "○", "上がり順位" = "6位" }
+comments = "堅実さはあるがもう一押しが欲しい。"
+
+[[horses]]
+post_position = 5
+number = 9
+name = "タイトルホルダー"
+sex_age = "牡5"
+weight = "58"
+jockey = "横山和生"
+running_style = "逃げ"
+ratings = { "枠順" = "A", "距離適性" = "S", "展開" = "S", "状態" = "A", "実績" = "S", "舞台" = "S", "瞬発力" = "B", "スタミナ" = "S" }
+notes = { "前走" = "日経賞 1着", "ローテ" = "中4週", "適性" = "芝長距離", "天候" = "晴◎", "ミドルペース" = "◎", "上がり順位" = "2位" }
+comments = "逃げれば圧倒的な粘り。"
+
+[[horses]]
+post_position = 8
+number = 15
+name = "ボルドグフーシュ"
+sex_age = "牡4"
+weight = "58"
+jockey = "川田将雅"
+running_style = "差し"
+ratings = { "枠順" = "C", "距離適性" = "A", "展開" = "B", "状態" = "A", "実績" = "A", "舞台" = "A", "瞬発力" = "A", "スタミナ" = "A" }
+notes = { "前走" = "阪神大賞典 2着", "ローテ" = "中5週", "適性" = "芝長距離", "天候" = "曇○", "ミドルペース" = "○", "上がり順位" = "3位" }
+comments = "外枠が課題だが末脚は脅威。"

--- a/generate_race_table.py
+++ b/generate_race_table.py
@@ -1,0 +1,41 @@
+"""Command-line interface to generate a race table HTML file."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent
+SRC_PATH = REPO_ROOT / "src"
+if SRC_PATH.exists() and str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+from keiba_table import load_race_table, render_html  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate a horse racing race-table from TOML data.")
+    parser.add_argument("input", type=Path, help="Path to the race definition TOML file")
+    parser.add_argument(
+        "output",
+        type=Path,
+        nargs="?",
+        help="Optional output path for the generated HTML file. Defaults to <input>.html",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    race_table = load_race_table(args.input)
+    html = render_html(race_table)
+
+    output_path = args.output or args.input.with_suffix(".html")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(html, encoding="utf-8")
+    print(f"Generated {output_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/output/sample_race.html
+++ b/output/sample_race.html
@@ -1,0 +1,115 @@
+
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <title>出走表</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Helvetica Neue", "Yu Gothic", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
+      }
+      body {
+        margin: 2rem;
+        background: #f7f7f7;
+        color: #222;
+      }
+      h1 {
+        margin-bottom: 0.25rem;
+        font-size: 1.75rem;
+      }
+      h2 {
+        margin-top: 0.25rem;
+        color: #555;
+        font-size: 1rem;
+      }
+      .distance-note {
+        margin-top: 0.5rem;
+        margin-bottom: 1rem;
+        font-size: 0.9rem;
+        color: #6c6c6c;
+      }
+      table.race-table {
+        width: 100%;
+        border-collapse: collapse;
+        background: #fff;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
+      table.race-table th,
+      table.race-table td {
+        border: 1px solid #d0d0d0;
+        padding: 0.45rem 0.35rem;
+        text-align: center;
+        font-size: 0.9rem;
+        line-height: 1.2;
+      }
+      table.race-table th {
+        background: #f0f0f0;
+        font-weight: 600;
+      }
+      table.race-table td.name {
+        text-align: left;
+        font-weight: 600;
+      }
+      .post-position {
+        font-weight: 700;
+      }
+      .rating-chip {
+        display: inline-block;
+        min-width: 1.75rem;
+        padding: 0.15rem 0.45rem;
+        border-radius: 999px;
+        font-weight: 700;
+        font-size: 0.75rem;
+        color: #fff;
+      }
+      .rating-s { background: #0d9488; }
+      .rating-a { background: #14b8a6; }
+      .rating-b { background: #0891b2; }
+      .rating-c { background: #6366f1; }
+      .rating-d { background: #a855f7; }
+      .rating-e { background: #f97316; }
+      .rating-generic { background: #6b7280; }
+      td.comments {
+        text-align: left;
+        font-size: 0.85rem;
+      }
+      .legend {
+        margin-top: 1.25rem;
+        padding-left: 1.2rem;
+        font-size: 0.85rem;
+        color: #444;
+      }
+      .legend li {
+        margin-bottom: 0.25rem;
+      }
+      footer {
+        margin-top: 1rem;
+        font-size: 0.8rem;
+        color: #666;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>今回の査定評価に関わる項目</h1>
+    <h2>天皇賞（春） 芝3200m (右外 C)</h2>
+    <div class="distance-note">※芝2000m以上/1600〜1800m</div>
+    <table class="race-table">
+      <thead>
+      <tr><th>枠</th><th>馬番</th><th>馬名</th><th>性齢</th><th>斤量</th><th>騎手</th><th>前走</th><th>ローテ</th><th>適性</th><th>天候</th><th>ミドルペース</th><th>上がり順位</th><th>脚質</th><th>枠順</th><th>距離適性</th><th>展開</th><th>調教</th><th>重賞実績</th><th>舞台適性</th><th>瞬発力</th><th>スタミナ</th><th>備考</th></tr>
+      </thead>
+      <tbody>
+        <tr><td class="post-position" style="background:#ffffff;color:#000000;">1</td><td>1</td><td class="name">アスクワイルドモア</td><td>牡4</td><td>58</td><td>岩田望来</td><td>日経賞 6着</td><td>中3週</td><td>芝長距離</td><td>雨◎</td><td>○</td><td>4位</td><td>差し</td><td><span class="rating-chip rating-a">A</span></td><td><span class="rating-chip rating-b">B</span></td><td><span class="rating-chip rating-b">B</span></td><td><span class="rating-chip rating-a">A</span></td><td><span class="rating-chip rating-b">B</span></td><td><span class="rating-chip rating-b">B</span></td><td><span class="rating-chip rating-b">B</span></td><td><span class="rating-chip rating-a">A</span></td><td class="comments">内枠を活かせれば上位争いも。</td></tr>
+        <tr><td class="post-position" style="background:#000000;color:#ffffff;">2</td><td>3</td><td class="name">ジャスティンパレス</td><td>牡4</td><td>58</td><td>C.ルメール</td><td>阪神大賞典 1着</td><td>中5週</td><td>芝長距離</td><td>晴◎</td><td>◎</td><td>1位</td><td>先行</td><td><span class="rating-chip rating-s">S</span></td><td><span class="rating-chip rating-a">A</span></td><td><span class="rating-chip rating-a">A</span></td><td><span class="rating-chip rating-s">S</span></td><td><span class="rating-chip rating-a">A</span></td><td><span class="rating-chip rating-a">A</span></td><td><span class="rating-chip rating-a">A</span></td><td><span class="rating-chip rating-a">A</span></td><td class="comments">長距離G2を快勝。状態も抜群。</td></tr>
+        <tr><td class="post-position" style="background:#ff4b4b;color:#ffffff;">3</td><td>5</td><td class="name">ブレークアップ</td><td>牡5</td><td>58</td><td>松山弘平</td><td>阪神大賞典 4着</td><td>中5週</td><td>芝長距離</td><td>晴○</td><td>○</td><td>6位</td><td>先行</td><td><span class="rating-chip rating-b">B</span></td><td><span class="rating-chip rating-b">B</span></td><td><span class="rating-chip rating-b">B</span></td><td><span class="rating-chip rating-b">B</span></td><td><span class="rating-chip rating-b">B</span></td><td><span class="rating-chip rating-b">B</span></td><td><span class="rating-chip rating-c">C</span></td><td><span class="rating-chip rating-b">B</span></td><td class="comments">堅実さはあるがもう一押しが欲しい。</td></tr>
+        <tr><td class="post-position" style="background:#ffd447;color:#000000;">5</td><td>9</td><td class="name">タイトルホルダー</td><td>牡5</td><td>58</td><td>横山和生</td><td>日経賞 1着</td><td>中4週</td><td>芝長距離</td><td>晴◎</td><td>◎</td><td>2位</td><td>逃げ</td><td><span class="rating-chip rating-a">A</span></td><td><span class="rating-chip rating-s">S</span></td><td><span class="rating-chip rating-s">S</span></td><td><span class="rating-chip rating-a">A</span></td><td><span class="rating-chip rating-s">S</span></td><td><span class="rating-chip rating-s">S</span></td><td><span class="rating-chip rating-b">B</span></td><td><span class="rating-chip rating-s">S</span></td><td class="comments">逃げれば圧倒的な粘り。</td></tr>
+        <tr><td class="post-position" style="background:#ff7fd1;color:#000000;">8</td><td>15</td><td class="name">ボルドグフーシュ</td><td>牡4</td><td>58</td><td>川田将雅</td><td>阪神大賞典 2着</td><td>中5週</td><td>芝長距離</td><td>曇○</td><td>○</td><td>3位</td><td>差し</td><td><span class="rating-chip rating-c">C</span></td><td><span class="rating-chip rating-a">A</span></td><td><span class="rating-chip rating-b">B</span></td><td><span class="rating-chip rating-a">A</span></td><td><span class="rating-chip rating-a">A</span></td><td><span class="rating-chip rating-a">A</span></td><td><span class="rating-chip rating-a">A</span></td><td><span class="rating-chip rating-a">A</span></td><td class="comments">外枠が課題だが末脚は脅威。</td></tr>
+      </tbody>
+    </table>
+    <section>
+      <h3>評価基準</h3>
+      <ul class="legend"><li><strong>枠順:</strong> S〜Eの5段階で内枠高評価。</li><li><strong>距離適性:</strong> 長距離経験の豊富さ。</li><li><strong>展開:</strong> 想定ペースとの相性。</li><li><strong>調教:</strong> 中間の調教内容。</li><li><strong>重賞実績:</strong> 重賞の実績。</li><li><strong>舞台適性:</strong> コースとの相性。</li><li><strong>瞬発力:</strong> 上がり性能。</li><li><strong>スタミナ:</strong> 持久力。</li></ul>
+    </section>
+    <footer>この表はサンプルデータを用いたデモンストレーションです。</footer>
+  </body>
+</html>

--- a/src/keiba_table/__init__.py
+++ b/src/keiba_table/__init__.py
@@ -1,0 +1,14 @@
+"""Utilities for generating Japanese horse racing entry tables."""
+
+from .models import AdditionalColumn, Criterion, HorseEntry, RaceTable
+from .render import render_html
+from .loader import load_race_table
+
+__all__ = [
+    "AdditionalColumn",
+    "Criterion",
+    "HorseEntry",
+    "RaceTable",
+    "render_html",
+    "load_race_table",
+]

--- a/src/keiba_table/loader.py
+++ b/src/keiba_table/loader.py
@@ -1,0 +1,81 @@
+"""Load race table definitions from TOML files."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+from .models import AdditionalColumn, Criterion, HorseEntry, RaceTable
+
+
+def _load_criteria(raw_criteria: Iterable[Any]) -> List[Criterion]:
+    criteria: List[Criterion] = []
+    for raw in raw_criteria:
+        criteria.append(Criterion.from_raw(raw))
+    keys = [criterion.key for criterion in criteria]
+    if len(keys) != len(set(keys)):
+        raise ValueError("Criterion keys must be unique")
+    return criteria
+
+
+def _load_additional_columns(raw_columns: Iterable[Any]) -> List[AdditionalColumn]:
+    columns: List[AdditionalColumn] = []
+    seen_keys: set[str] = set()
+    for raw in raw_columns:
+        column = AdditionalColumn.from_raw(raw)
+        if column.key in seen_keys:
+            raise ValueError("Additional column keys must be unique")
+        seen_keys.add(column.key)
+        columns.append(column)
+    return columns
+
+
+def load_race_table(path: str | Path) -> RaceTable:
+    """Load race table data from a TOML file."""
+
+    data: Dict[str, Any]
+    with open(path, "rb") as fp:
+        data = tomllib.load(fp)
+
+    race_info = data.get("race")
+    if not isinstance(race_info, dict):
+        raise ValueError("TOML file must contain a [race] table")
+
+    title = str(race_info.get("title") or "出走表")
+    subtitle = race_info.get("subtitle")
+    distance_note = race_info.get("distance_note")
+
+    raw_criteria = data.get("criteria", [])
+    if not isinstance(raw_criteria, list) or not raw_criteria:
+        raise ValueError("TOML file must contain a [ [criteria] ] array with at least one item")
+
+    criteria = _load_criteria(raw_criteria)
+
+    raw_additional_columns = race_info.get("additional_columns", [])
+    if not isinstance(raw_additional_columns, list):
+        raise TypeError("race.additional_columns must be an array")
+    additional_columns = _load_additional_columns(raw_additional_columns)
+
+    legend = data.get("legend", {})
+    if not isinstance(legend, dict):
+        raise TypeError("legend must be a table of criterion key to description")
+
+    footnote = race_info.get("footnote")
+
+    raw_horses = data.get("horses")
+    if not isinstance(raw_horses, list) or not raw_horses:
+        raise ValueError("TOML file must contain a [ [horses] ] array with at least one entry")
+
+    horses = [HorseEntry.from_raw(entry, criteria, additional_columns) for entry in raw_horses]
+
+    return RaceTable(
+        title=title,
+        subtitle=str(subtitle) if subtitle else None,
+        distance_note=str(distance_note) if distance_note else None,
+        criteria=criteria,
+        horses=horses,
+        additional_columns=additional_columns,
+        legend={str(key): str(value) for key, value in legend.items()},
+        footnote=str(footnote) if footnote else None,
+    )

--- a/src/keiba_table/models.py
+++ b/src/keiba_table/models.py
@@ -1,0 +1,144 @@
+"""Data models for the race table generator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence
+
+
+@dataclass(slots=True)
+class AdditionalColumn:
+    """Represents an additional informational column displayed per horse."""
+
+    key: str
+    label: str
+
+    @staticmethod
+    def from_raw(raw: Dict[str, str] | str) -> "AdditionalColumn":
+        """Convert TOML values into an :class:`AdditionalColumn` instance."""
+
+        if isinstance(raw, str):
+            return AdditionalColumn(key=raw, label=raw)
+        if not isinstance(raw, dict):  # pragma: no cover - defensive programming
+            raise TypeError("Additional column definitions must be strings or tables")
+
+        key = raw.get("key")
+        if not key:
+            raise ValueError("Additional column tables must include a 'key'")
+        label = raw.get("label", key)
+        return AdditionalColumn(key=str(key), label=str(label))
+
+
+@dataclass(slots=True)
+class Criterion:
+    """Represents an evaluation criterion displayed in the table."""
+
+    key: str
+    label: str
+    description: Optional[str] = None
+
+    @staticmethod
+    def from_raw(raw: Dict[str, str] | str) -> "Criterion":
+        """Convert raw values loaded from TOML into a :class:`Criterion`."""
+
+        if isinstance(raw, str):
+            return Criterion(key=raw, label=raw)
+        key = raw.get("key")
+        label = raw.get("label", key)
+        if not key or not label:
+            raise ValueError("Criterion definitions must include at least a key and label")
+        return Criterion(key=key, label=label, description=raw.get("description"))
+
+
+@dataclass(slots=True)
+class HorseEntry:
+    """Represents a single horse entry row in the table."""
+
+    post_position: int
+    number: int
+    name: str
+    sex_age: str
+    weight: str
+    jockey: str
+    running_style: Optional[str] = None
+    comments: Optional[str] = None
+    ratings: Dict[str, str] = field(default_factory=dict)
+    notes: Dict[str, str] = field(default_factory=dict)
+
+    @staticmethod
+    def from_raw(
+        raw: Dict[str, object],
+        criteria: Sequence[Criterion],
+        additional_columns: Sequence["AdditionalColumn"] | None = None,
+    ) -> "HorseEntry":
+        missing = {field for field in ["post_position", "number", "name", "sex_age", "weight", "jockey"] if field not in raw}
+        if missing:
+            raise ValueError(f"Horse entry is missing required fields: {', '.join(sorted(missing))}")
+
+        ratings = raw.get("ratings", {})
+        if not isinstance(ratings, dict):
+            raise TypeError("'ratings' must be a table of criterion key to rating value")
+
+        notes = raw.get("notes", {})
+        if not isinstance(notes, dict):
+            raise TypeError("'notes' must be a table of column key to text value")
+
+        if additional_columns:
+            valid_note_keys = {column.key for column in additional_columns}
+            invalid_notes = sorted(set(notes) - valid_note_keys)
+            if invalid_notes:
+                raise ValueError(
+                    f"Horse entry '{raw.get('name')}' contains notes for unknown columns: {', '.join(invalid_notes)}"
+                )
+
+        # Ensure only known criteria keys appear in ratings.
+        valid_keys = {criterion.key for criterion in criteria}
+        invalid = sorted(set(ratings) - valid_keys)
+        if invalid:
+            raise ValueError(f"Horse entry '{raw.get('name')}' contains ratings for unknown criteria: {', '.join(invalid)}")
+
+        return HorseEntry(
+            post_position=int(raw["post_position"]),
+            number=int(raw["number"]),
+            name=str(raw["name"]),
+            sex_age=str(raw["sex_age"]),
+            weight=str(raw["weight"]),
+            jockey=str(raw["jockey"]),
+            running_style=str(raw.get("running_style")) if raw.get("running_style") is not None else None,
+            comments=str(raw.get("comments")) if raw.get("comments") is not None else None,
+            ratings={str(key): str(value) for key, value in ratings.items()},
+            notes={str(key): str(value) for key, value in notes.items()},
+        )
+
+
+@dataclass(slots=True)
+class RaceTable:
+    """Aggregates all information required to render the race table."""
+
+    title: str
+    subtitle: Optional[str]
+    distance_note: Optional[str]
+    criteria: List[Criterion]
+    horses: List[HorseEntry]
+    additional_columns: List[AdditionalColumn] = field(default_factory=list)
+    legend: Dict[str, str] = field(default_factory=dict)
+    footnote: Optional[str] = None
+
+    @property
+    def has_running_style(self) -> bool:
+        return any(entry.running_style for entry in self.horses)
+
+    @property
+    def has_comments(self) -> bool:
+        return any(entry.comments for entry in self.horses)
+
+    def column_headers(self) -> List[str]:
+        base = ["枠", "馬番", "馬名", "性齢", "斤量", "騎手"]
+        if self.additional_columns:
+            base.extend(column.label for column in self.additional_columns)
+        if self.has_running_style:
+            base.append("脚質")
+        base.extend(criterion.label for criterion in self.criteria)
+        if self.has_comments:
+            base.append("備考")
+        return base

--- a/src/keiba_table/render.py
+++ b/src/keiba_table/render.py
@@ -1,0 +1,226 @@
+"""Render race tables to HTML."""
+
+from __future__ import annotations
+
+from html import escape
+from textwrap import dedent
+from typing import Iterable, Sequence
+
+from .models import AdditionalColumn, Criterion, HorseEntry, RaceTable
+
+BRACKET_COLORS = {
+    1: "#ffffff",
+    2: "#000000",
+    3: "#ff4b4b",
+    4: "#1a7cff",
+    5: "#ffd447",
+    6: "#3ab66b",
+    7: "#ff7f27",
+    8: "#ff7fd1",
+}
+
+BRACKET_TEXT_COLORS = {
+    1: "#000000",
+    2: "#ffffff",
+    3: "#ffffff",
+    4: "#ffffff",
+    5: "#000000",
+    6: "#ffffff",
+    7: "#000000",
+    8: "#000000",
+}
+
+RATING_CLASSES = {
+    "S": "rating-s",
+    "A": "rating-a",
+    "B": "rating-b",
+    "C": "rating-c",
+    "D": "rating-d",
+    "E": "rating-e",
+}
+
+
+def _render_rating_cell(rating: str | None) -> str:
+    if not rating:
+        return ""
+    css_class = RATING_CLASSES.get(rating.upper(), "rating-generic")
+    return f'<span class="rating-chip {css_class}">{escape(rating)}</span>'
+
+
+def _render_additional_columns(entry: HorseEntry, columns: Sequence[AdditionalColumn]) -> Iterable[str]:
+    for column in columns:
+        text = entry.notes.get(column.key, "")
+        yield f"<td>{escape(text)}</td>"
+
+
+def _render_legend(criteria: Iterable[Criterion], legend: dict[str, str]) -> str:
+    items = []
+    for criterion in criteria:
+        text = legend.get(criterion.key) or criterion.description
+        if not text:
+            continue
+        items.append(f"<li><strong>{escape(criterion.label)}:</strong> {escape(text)}</li>")
+    if not items:
+        return ""
+    return "<ul class=\"legend\">" + "".join(items) + "</ul>"
+
+
+def render_html(table: RaceTable) -> str:
+    """Render the race table to an HTML string."""
+
+    head = dedent(
+        """
+        <!DOCTYPE html>
+        <html lang="ja">
+          <head>
+            <meta charset="utf-8" />
+            <title>出走表</title>
+            <style>
+              :root {
+                color-scheme: light;
+                font-family: "Helvetica Neue", "Yu Gothic", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
+              }
+              body {
+                margin: 2rem;
+                background: #f7f7f7;
+                color: #222;
+              }
+              h1 {
+                margin-bottom: 0.25rem;
+                font-size: 1.75rem;
+              }
+              h2 {
+                margin-top: 0.25rem;
+                color: #555;
+                font-size: 1rem;
+              }
+              .distance-note {
+                margin-top: 0.5rem;
+                margin-bottom: 1rem;
+                font-size: 0.9rem;
+                color: #6c6c6c;
+              }
+              table.race-table {
+                width: 100%;
+                border-collapse: collapse;
+                background: #fff;
+                box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+              }
+              table.race-table th,
+              table.race-table td {
+                border: 1px solid #d0d0d0;
+                padding: 0.45rem 0.35rem;
+                text-align: center;
+                font-size: 0.9rem;
+                line-height: 1.2;
+              }
+              table.race-table th {
+                background: #f0f0f0;
+                font-weight: 600;
+              }
+              table.race-table td.name {
+                text-align: left;
+                font-weight: 600;
+              }
+              .post-position {
+                font-weight: 700;
+              }
+              .rating-chip {
+                display: inline-block;
+                min-width: 1.75rem;
+                padding: 0.15rem 0.45rem;
+                border-radius: 999px;
+                font-weight: 700;
+                font-size: 0.75rem;
+                color: #fff;
+              }
+              .rating-s { background: #0d9488; }
+              .rating-a { background: #14b8a6; }
+              .rating-b { background: #0891b2; }
+              .rating-c { background: #6366f1; }
+              .rating-d { background: #a855f7; }
+              .rating-e { background: #f97316; }
+              .rating-generic { background: #6b7280; }
+              td.comments {
+                text-align: left;
+                font-size: 0.85rem;
+              }
+              .legend {
+                margin-top: 1.25rem;
+                padding-left: 1.2rem;
+                font-size: 0.85rem;
+                color: #444;
+              }
+              .legend li {
+                margin-bottom: 0.25rem;
+              }
+              footer {
+                margin-top: 1rem;
+                font-size: 0.8rem;
+                color: #666;
+              }
+            </style>
+          </head>
+        """
+    )
+
+    body_parts = ["  <body>"]
+    body_parts.append(f"    <h1>{escape(table.title)}</h1>")
+    if table.subtitle:
+        body_parts.append(f"    <h2>{escape(table.subtitle)}</h2>")
+    if table.distance_note:
+        body_parts.append(f"    <div class=\"distance-note\">{escape(table.distance_note)}</div>")
+
+    body_parts.append("    <table class=\"race-table\">")
+
+    headers = table.column_headers()
+    header_html = "      <tr>" + "".join(f"<th>{escape(header)}</th>" for header in headers) + "</tr>"
+    body_parts.append("      <thead>")
+    body_parts.append(header_html)
+    body_parts.append("      </thead>")
+    body_parts.append("      <tbody>")
+
+    for entry in table.horses:
+        row_cells = []
+        background = BRACKET_COLORS.get(entry.post_position)
+        text_color = BRACKET_TEXT_COLORS.get(entry.post_position, "#000000")
+        style_attr = ""
+        if background:
+            style_attr = f' style="background:{background};color:{text_color};"'
+        row_cells.append(
+            f"<td class=\"post-position\"{style_attr}>{escape(str(entry.post_position))}</td>"
+        )
+        row_cells.append(f"<td>{escape(str(entry.number))}</td>")
+        row_cells.append(f"<td class=\"name\">{escape(entry.name)}</td>")
+        row_cells.append(f"<td>{escape(entry.sex_age)}</td>")
+        row_cells.append(f"<td>{escape(entry.weight)}</td>")
+        row_cells.append(f"<td>{escape(entry.jockey)}</td>")
+        if table.additional_columns:
+            row_cells.extend(_render_additional_columns(entry, table.additional_columns))
+        if table.has_running_style:
+            row_cells.append(f"<td>{escape(entry.running_style or '')}</td>")
+        for criterion in table.criteria:
+            rating = entry.ratings.get(criterion.key)
+            row_cells.append(f"<td>{_render_rating_cell(rating)}</td>")
+        if table.has_comments:
+            row_cells.append(f"<td class=\"comments\">{escape(entry.comments or '')}</td>")
+
+        body_parts.append("        <tr>" + "".join(row_cells) + "</tr>")
+
+    body_parts.append("      </tbody>")
+    body_parts.append("    </table>")
+
+    legend_html = _render_legend(table.criteria, table.legend)
+    if legend_html:
+        body_parts.append("    <section>")
+        body_parts.append("      <h3>評価基準</h3>")
+        body_parts.append(f"      {legend_html}")
+        body_parts.append("    </section>")
+
+    if table.footnote:
+        body_parts.append(f"    <footer>{escape(table.footnote)}</footer>")
+
+    body_parts.append("  </body>")
+    body_parts.append("</html>")
+
+    return head + "\n".join(body_parts) + "\n"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Test package for the race table generator."""
+

--- a/tests/test_race_table.py
+++ b/tests/test_race_table.py
@@ -1,0 +1,93 @@
+"""Unit tests for the race table loader and renderer."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from textwrap import dedent
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from keiba_table import load_race_table, render_html  # noqa: E402
+
+
+class RaceTableTests(unittest.TestCase):
+    def _write_toml(self, directory: Path, content: str) -> Path:
+        path = directory / "race.toml"
+        path.write_text(dedent(content), encoding="utf-8")
+        return path
+
+    def test_structured_additional_columns_are_loaded(self) -> None:
+        toml_content = """
+        [race]
+        title = "テスト"
+        additional_columns = [
+          { key = "prev_race", label = "前走" },
+          "ローテ"
+        ]
+
+        [[criteria]]
+        key = "speed"
+        label = "スピード"
+        description = "スピード評価について"
+
+        [[horses]]
+        post_position = 1
+        number = 1
+        name = "テストホース"
+        sex_age = "牡4"
+        weight = "58"
+        jockey = "騎手"
+        ratings = { speed = "A" }
+        notes = { prev_race = "日経賞", "ローテ" = "中2週" }
+        """
+
+        with TemporaryDirectory() as tmpdir:
+            directory = Path(tmpdir)
+            path = self._write_toml(directory, toml_content)
+            table = load_race_table(path)
+
+            self.assertEqual(["prev_race", "ローテ"], [c.key for c in table.additional_columns])
+            self.assertEqual(["前走", "ローテ"], [c.label for c in table.additional_columns])
+            self.assertEqual("日経賞", table.horses[0].notes["prev_race"])
+            self.assertEqual("中2週", table.horses[0].notes["ローテ"])
+
+            html = render_html(table)
+            self.assertIn("<th>前走</th>", html)
+            self.assertIn("<th>ローテ</th>", html)
+            self.assertIn("<td>日経賞</td>", html)
+            self.assertIn("<td>中2週</td>", html)
+            self.assertIn("<strong>スピード:</strong> スピード評価について", html)
+
+    def test_unknown_additional_column_key_raises(self) -> None:
+        toml_content = """
+        [race]
+        title = "エラー"
+        additional_columns = [ { key = "prev", label = "前走" } ]
+
+        [[criteria]]
+        key = "speed"
+        label = "スピード"
+
+        [[horses]]
+        post_position = 1
+        number = 1
+        name = "エラーホース"
+        sex_age = "牡3"
+        weight = "56"
+        jockey = "騎手"
+        ratings = { speed = "B" }
+        notes = { unknown = "should fail" }
+        """
+
+        with TemporaryDirectory() as tmpdir:
+            directory = Path(tmpdir)
+            path = self._write_toml(directory, toml_content)
+            with self.assertRaisesRegex(ValueError, "unknown columns"):
+                load_race_table(path)
+


### PR DESCRIPTION
## Summary
- allow `race.additional_columns` entries to supply separate keys and labels and expose the new `AdditionalColumn` model for downstream use
- validate horse notes against the configured columns, reuse computed headers in the renderer, and fall back to criterion descriptions when no legend text is provided
- document the keyed column support in the README and add unit tests covering the loader and renderer behaviour

## Testing
- python generate_race_table.py data/sample_race.toml output/sample_race.html
- python -m unittest


------
https://chatgpt.com/codex/tasks/task_e_68c9785bb8708322a33d6562cba2c92a